### PR TITLE
Qtype gapselect showing Did you remember to call setType() errors on edi...

### DIFF
--- a/edit_form_base.php
+++ b/edit_form_base.php
@@ -163,6 +163,7 @@ class qtype_gapselect_edit_form_base extends question_edit_form {
     protected function repeated_options() {
         $repeatedoptions = array();
         $repeatedoptions['choicegroup']['default'] = '1';
+        $repeatedoptions['choices[answer]']['type'] = PARAM_TEXT;
         return $repeatedoptions;
     }
 


### PR DESCRIPTION
...ting form #6846

A one line fix. This is a standard Moodle 2.5 problem.
